### PR TITLE
Don't depend on *read-default-float-format*.

### DIFF
--- a/dev/anova.lisp
+++ b/dev/anova.lisp
@@ -125,7 +125,7 @@ representation.  See the manual for more information."
 			 (scheffe-tests group-means group-sizes mse dfe))
 		       sst-alt
 		       (when (and (numberp confidence-intervals)
-				  (< 0.0 confidence-intervals 1.0))
+				  (< 0f0 confidence-intervals 1f0))
 			 (let ((current-group '#:new)
 			       (group-sums-squared nil))
 			   (map nil #'(lambda (key value)
@@ -225,7 +225,7 @@ representation.  See the manual for more information."
 				     mse dfe))
 		    sst-alt
 		    (when (and (numberp confidence-intervals)
-			       (< 0.0 confidence-intervals 1.0))
+			       (< 0f0 confidence-intervals 1f0))
 		      (map 'list #'(lambda (group)
 				     (multiple-value-list
 				       (confidence-interval-t group confidence-intervals)))

--- a/dev/basic-statistics.lisp
+++ b/dev/basic-statistics.lisp
@@ -272,8 +272,8 @@ number."
       ;; and there is less than 2 items left or (2) n is odd and there is less
       ;; than one item left.
       (if (if (evenp n)
-	      (<= (- n (* 2 n percentage)) 2.0)
-	      (<= (- n (* 2 n percentage)) 1.0))
+	      (<= (- n (* 2 n percentage)) 2f0)
+	      (<= (- n (* 2 n percentage)) 1f0))
 	  ;; Not enough left, so take median
 	  (if (evenp n)
 	      (if (null key)
@@ -1313,7 +1313,7 @@ respectively.  In this case, the G-test is a test of independence.  The degrees 
 ;;; ---------------------------------------------------------------------------
 
 (defun find-critical-value
-       (p-function p-value &optional (x-tolerance .00001) (y-tolerance .00001))
+       (p-function p-value &optional (x-tolerance 1f-5) (y-tolerance 1f-5))
   "Returns the critical value of some statistic.  The function `p-function'
 should be a unary function mapping statistics---x values---to their
 significance---p values.  The function will find the value of x such that the
@@ -1327,9 +1327,9 @@ value at x=0.  The binary search ends when either the function value is within
   ;; It generates this erroneous code...
   ;; (AND (TYPEP #:G3682 'REAL) (> (THE REAL #:G3682) (0)) ...)
   #-(or allegro lucid) (check-type p-value (real (0) (1)))
-  (let* ((x-low 0.0)
-	 (fx-low 1.0)
-	 (x-high 1.0)
+  (let* ((x-low 0f0)
+	 (fx-low 1f0)
+	 (x-high 1f0)
 	 (fx-high (funcall p-function x-high)))
     ;; double up
     (do () (nil)
@@ -1340,11 +1340,11 @@ value at x=0.  The binary search ends when either the function value is within
 	(return))
       (setf x-low x-high
 	    fx-low fx-high
-	    x-high (* 2.0 x-high)
+	    x-high (* 2f0 x-high)
 	    fx-high (funcall p-function x-high)))
     ;; binary search
     (do () (nil)
-      (let* ((x-mid  (/ (+ x-low x-high) 2.0))
+      (let* ((x-mid  (/ (+ x-low x-high) 2f0))
 	     (fx-mid (funcall p-function x-mid))
 	     (y-diff (abs (- fx-mid p-value)))
 	     (x-diff (- x-high x-low)))
@@ -1363,13 +1363,13 @@ value at x=0.  The binary search ends when either the function value is within
 
 #+test
 (defun test-find-critical-value ()
-  (dolist (alpha '(.1 .05 .01))
+  (dolist (alpha '(1f-1 5f-2 1f-2))
     (format t "x to give alpha = ~4,2f is:  ~5,3f~%"
 	    alpha
 	    (find-critical-value #'(lambda (x) (gaussian-significance x :both))
 				 alpha)))
   (dolist (dof '(2 5 10))
-    (dolist (alpha '(.1 .05 .01))
+    (dolist (alpha '(1f-1 5f-2 1f-2))
       (format t "with ~2d dof, the t to give upper-tail alpha = ~4,2f is:  ~5,3f~%"
 	      dof
 	      alpha

--- a/dev/correlation-regression.lisp
+++ b/dev/correlation-regression.lisp
@@ -201,7 +201,7 @@ statistics."
 	   (determination (/ NSSR NSSY))
 	   (dof           (- n 2))
 	   (std-err-slope (sqrt (/ NSSE (* dof NSSX))))
-	   (p-value       (if (zerop NSSE) 0.0 
+	   (p-value       (if (zerop NSSE) 0f0
 			      (students-t-significance
 			       ;; Need a float here.
 			       (coerce (/ slope std-err-slope) 'float)
@@ -495,7 +495,7 @@ correlation coefficient for Y on X's."
 	  ;;calculate and list the portion of the sum of squares of the regression due 
 	  ;; to each X.
 	       
-	  '(let ((sum-y 0.0) (sum-z 0.0) (sum-z2 0.0) (sum-zy 0.0) (sum-y2 0.0))
+	  '(let ((sum-y 0f0) (sum-z 0f0) (sum-z2 0f0) (sum-zy 0f0) (sum-y2 0f0))
 	    (apply #'mapc
 		   #'(lambda (y &rest xs)
 		       (let ((z (loop for x in xs for c in coefficients
@@ -628,7 +628,7 @@ sibling functions -minimal and -verbose if you want less or more information."
   (multiple-value-bind (a b) (apply #'multiple-linear-regression-arrays dv ivs)
     (let ((x (svd-solve-linear-system a b nil)))
       (destructuring-bind (rows cols) (array-dimensions a)
-	(let ((SSE 0.0))
+	(let ((SSE 0f0))
 	  (dotimes (i rows)
 	    (let* ((model (loop for j from 0 below cols
 				sum (* (aref a i j) (aref x j))))
@@ -666,17 +666,17 @@ the sibling functions -minimal and -brief if you need less information."
 	      Bs		; the solution vector
 	      betas		; the standardized coefficients
 	      Ts		; the t-statistics for the b's.
-	      (SST 0.0)		; total sum of squares
-	      (SSE 0.0)		; sum squared error of residuals
+	      (SST 0f0)		; total sum of squares
+	      (SSE 0f0)		; sum squared error of residuals
 	      MSE		; mean squared error of residuals
-	      (SSR 0.0)		; sum squares due to regression
+	      (SSR 0f0)		; sum squares due to regression
 	      MSR		; mean square regression
 	      R2		; R-squared, the fraction variance accounted for
 	      F			; F ratio
 	      cov		; covariance matrix (among the coefficients)
 	      cor		; correlation matrix (among the variables)
 	      ssr-portions)	; portion of SSR for each iv
-	  (setf zeroed (svd-zero w 1.0e-6 nil))
+	  (setf zeroed (svd-zero w 1f-6 nil))
 	  
 	  ;; The solution vector includes all coefficients and the intercept,
 	  ;; which is the zeroth element.
@@ -684,7 +684,7 @@ the sibling functions -minimal and -brief if you need less information."
 	  
 	  ;; calculate SSE directly by computing predicted dv, subtracting
 	  ;; true dv, squaring and summing.  Also compute SST
-	  (let ((sum-y 0.0) (sum-y2 0.0) (sum-z 0.0) (sum-z2 0.0))
+	  (let ((sum-y 0f0) (sum-y2 0f0) (sum-z 0f0) (sum-z2 0f0))
 	    (dotimes (i n)
 	      (let* ((data  (aref y i))
 		     (model (loop for j from 0 below k
@@ -789,7 +789,7 @@ variable is row and column zero."
     (push dv ivs)
     (let ((matrix (make-array (list n n) :element-type 'single-float)))
       (dotimes (i n)
-	(setf (aref matrix i i) 1.0))
+	(setf (aref matrix i i) 1f0))
       (loop for v1 in ivs for i from 0 do
 	    (loop for v2 in ivs for j from 0 below i do
 		  (let ((r (r-score v1 v2)))

--- a/dev/density-fns.lisp
+++ b/dev/density-fns.lisp
@@ -123,7 +123,7 @@ Numerical Recipes in C, section 6.1"
     (cond ((< n 0)
 	   (error "N cannot be negative:  ~d" n))
 	  ((<= n 1)
-	   0.0)
+	   0f0)
 	  ((< n (length cache))
 	   (aref cache n))
 	  (t
@@ -163,7 +163,7 @@ function, `binomial-coefficient.'"
 	   (if (= level 0)
 	       (= x y)
 	       ;; returns true if fractional error is less than `level'
-	       (<= (/ (* 2.0 (abs (- x y))) (+ x y)) level))))
+	       (<= (/ (* 2f0 (abs (- x y))) (+ x y)) level))))
     (flet ((test-range (min max level)
 	     (do ((n min (1+ n)))
 		 ((> n max))
@@ -192,11 +192,11 @@ approximations, and so is computationally efficient but not necessarily exact."
   ;; Rather than signal an error if p is extreme, we might as well try to return
   ;; something sensible.  In fact, the exact function returns the same values.
   (case p
-    (0.0 (if (zerop k) 1.0 0.0))
-    (1.0 (if (= k n) 1.0 0.0))
+    (0.0 (if (zerop k) 1f0 0f0))
+    (1.0 (if (= k n) 1f0 0f0))
     (t   (exp (+ (- (factorial-ln n) (factorial-ln k) (factorial-ln (- n k)))
 		 (* k (log p))
-		 (* (- n k) (log (- 1.0 p))))))))
+		 (* (- n k) (log (- 1f0 p))))))))
 
 (defun binomial-probability-exact (p n k)
   "This is an exact but computationally intensive form of the preferred
@@ -255,7 +255,7 @@ Instead, it just returns 0.0d0"
 	#+Lucid lcl::floating-point-underflow
 	(condition)
 	(declare (ignore condition))
-	(values 0.0d0))))
+	(values 0.0f0))))
 
 #| Grabbed this off the net.
 
@@ -278,22 +278,22 @@ Instead, it just returns 0.0d0"
 manual for more information."
   (check-type a float)
   (check-type x float)
-  (assert (> a 0.0) (a) "a must be positive:  ~g" a)
-  (assert (>= x 0.0) (x) "x must be non-negative:  ~g" x)
+  (assert (> a 0f0) (a) "a must be positive:  ~g" a)
+  (assert (>= x 0f0) (x) "x must be non-negative:  ~g" x)
   (let ((gln (gamma-ln a)))
-    (when (= x 0.0)
-      (return-from gamma-incomplete (values 0.0 gln)))
-      (if (< x (+ a 1.0))
+    (when (= x 0f0)
+      (return-from gamma-incomplete (values 0f0 gln)))
+      (if (< x (+ a 1f0))
 	  ;; Use series representation.  The following is the code of what
 	  ;; Numerical Recipes in C calls ``GSER'
 	  (let* ((itmax 100)
-		 (eps   3.0e-7)
+		 (eps   3f-7)
 		 (ap    a)
-		 (sum   (/ 1.0 a))
+		 (sum   (/ 1f0 a))
 		 (del sum))
 	    (declare (type float ap sum del))
 	    (dotimes (i itmax)
-	      (incf ap 1.0)
+	      (incf ap 1f0)
 	      (setf del (* del (/ x ap)))
 	      (incf sum del)
 	      (if (< (abs del) (* eps (abs sum)))
@@ -307,9 +307,9 @@ manual for more information."
 	  ;; computes the complement of the desired result, so we subtract from
 	  ;; 1.0 at the end.
 	  (let ((itmax 100)
-		(eps   3.0e-7)
-		(gold 0.0) (g 0.0) (fac 1.0) (b1 1.0) (b0 0.0)
-		(anf 0.0) (ana 0.0) (an 0.0) (a1 x) (a0 1.0))
+		(eps   3f-7)
+		(gold 0f0) (g 0f0) (fac 1f0) (b1 1f0) (b0 0f0)
+		(anf 0f0) (ana 0f0) (an 0f0) (a1 x) (a0 1f0))
 	    (declare (type float gold g fac b1 b0 anf ana an a1 a0))
 	    (dotimes (i itmax)
 	      (setf an  (float (1+ i))
@@ -320,13 +320,13 @@ manual for more information."
 		    a1  (+ (* x a0) (* anf a1))
 		    b1  (+ (* x b0) (* anf b1)))
 	      (unless (zerop a1)
-		(setf fac (/ 1.0 a1)
+		(setf fac (/ 1f0 a1)
 		      g   (* b1 fac))
 		(if (< (abs (/ (- g gold) g)) eps)
 		    (let ((result (underflow-goes-to-zero
 				   (* (safe-exp (- (* a (log x)) x gln)) g))))
 		      (return-from
-			gamma-incomplete (values (- 1.0 result) gln)))
+			gamma-incomplete (values (- 1f0 result) gln)))
 		    (setf gold g))))
 	    (error "Continued Fraction didn't converge:~%~
                   Either a=~s is too large, or ITMAX=~d is too small." a itmax)))))
@@ -349,10 +349,10 @@ function.  It also reports particular values, which can be compared to tables."
 		 (push (list x (gamma-incomplete a (float x))) pts))
 	       `((:polyline-without-vertices ,(format nil "a = ~s" a) 0) . ,pts))))
       (plotter:plot-stuff
-	(list (igf 0.5)
-	      (igf 1.0)
-	      (igf 3.0)
-	      (igf 10.0))
+	(list (igf 5f-1)
+	      (igf 1f0)
+	      (igf 3f0)
+	      (igf 1f1))
 	:title "The incomplete gamma function P(a,x) for a=.5, 1.0, 3.0, and 10.0"))))
 
 ;;; ============================================================================
@@ -363,26 +363,26 @@ the Gaussian probability distribution.  See the manual for more information.
 Also see the function `gaussian-cdf.'
 
 This implementation follows Numerical Recipes in C, section 6.2"
-  (let ((erf (gamma-incomplete .5 (square x))))	; for x>0
+  (let ((erf (gamma-incomplete .5f0 (square x))))	; for x>0
     ;; because erf(-x)=-erf(x)
-    (if (>= x 0.0) erf (- erf))))
+    (if (>= x 0f0) erf (- erf))))
 
-(defun gaussian-cdf (x &optional (mean 0.0) (sd 1.0))
+(defun gaussian-cdf (x &optional (mean 0f0) (sd 1f0))
   "Computes the cumulative distribution function for a Gaussian random variable
 \(defaults: mean=0.0, s.d.=1.0\) evaluated at `x.' The result is the probability
 of getting a random number less than or equal to `x,' from the given Gaussian
 distribution."
-  (when (= sd 0.0)
+  (when (= sd 0f0)
     (if *gaussian-cdf-signals-zero-standard-deviation-error*
         (error 'zero-standard-deviation)
-      (if (> x mean) (return-from gaussian-cdf  1.0) (return-from gaussian-cdf 0.0))))
+      (if (> x mean) (return-from gaussian-cdf  1f0) (return-from gaussian-cdf 0f0))))
   (let ((z (/ (- x mean) sd)))
-    (* .5 (+ 1.0 (error-function (/ z (sqrt 2.0)))))))
+    (* .5 (+ 1f0 (error-function (/ z (sqrt 2f0)))))))
 
 #+test
 (defun test-error-function ()
   ;; just compare to tabulated values in any statistics book
-  (dolist (x '(-3.0 -2.0 -1.0 0.0 1.0 2.0 3.0))
+  (dolist (x '(-3f0 -2f0 -1f0 0f0 1f0 2f0 3f0))
     (format t "Gaussian CDF of ~4f is ~f~%" x (gaussian-cdf x))))
 
 (defun error-function-complement (x)
@@ -397,33 +397,33 @@ that is the one they call from their statistical functions.  It is quick to
 compute and has fractional error everywhere less than 1.2x10^\\{-7\\}."
   (check-type x float)
   (let* ((z   (abs x))
-	 (y   (/ 1.0 (+ 1.0 (* 0.5 z))))   ; instead of t
+	 (y   (/ 1f0 (+ 1f0 (* 5d-1 z))))   ; instead of t
 	 (ans
           (error-function-complement-short-1 y z)
           #+COMPILER-BUG
           (* y (exp (+ (* (- z) z)
-                       -1.26551223
+                       -1.26551223f0
                        (* y
-                          (+ 1.00002368
+                          (+ 1.00002368f0
                              (* y
-                                (+ 0.37409196
+                                (+ 0.37409196f0
                                    (* y
-                                      (+ 0.09678418
+                                      (+ 0.09678418f0
                                          (* y
-                                            (+ -0.18628806
+                                            (+ -0.18628806f0
                                                (* y
-                                                  (+ 0.27886807
+                                                  (+ 0.27886807f0
                                                      (* y
-                                                        (+ -1.13520398
+                                                        (+ -1.13520398f0
                                                            (* y
-                                                              (+ 1.48851587
+                                                              (+ 1.48851587f0
                                                                  (* y
-                                                                    (+ -0.82215223
-                                                                       (* y 0.17087277))))))))))))))))))))))
+                                                                    (+ -0.82215223f0
+                                                                       (* y 0.17087277f0))))))))))))))))))))))
     (declare (type float z y ans))
-    (if (>= x 0.0)
+    (if (>= x 0f0)
       ans
-      (- 2.0 ans))))
+      (- 2f0 ans))))
 
 #+CRAP ;Compiler bug here.  (Westy)
 (defun error-function-complement-helper (y z)
@@ -449,48 +449,48 @@ compute and has fractional error everywhere less than 1.2x10^\\{-7\\}."
 
 (defun error-function-complement-short-1 (y z)
   (* y (exp (+ (* (- z) z)
-               -1.26551223
-               (* y 
-		  (+ 1.00002368
-		     (* y 
-			(+ 0.37409196
-			   (* y 
-			      (+ 0.09678418
-				 (* y 
-				    (+ -0.18628806
+               -1.26551223f0
+               (* y
+		  (+ 1.00002368f0
+		     (* y
+			(+ 0.37409196f0
+			   (* y
+			      (+ 0.09678418f0
+				 (* y
+				    (+ -0.18628806f0
                                        (error-function-complement-short-2 y)))))))))))))
 
 (defun error-function-complement-short-2 (y)
-  (* y 
-     (+ 0.27886807
-        (* y 
-           (+ -1.13520398
-              (* y 
-                 (+ 1.48851587
-                    (* y 
-                       (+ -0.82215223
-                          (* y 0.17087277))))))))))
+  (* y
+     (+ 0.27886807f0
+        (* y
+           (+ -1.13520398f0
+              (* y
+                 (+ 1.48851587f0
+                    (* y
+                       (+ -0.82215223f0
+                          (* y 0.17087277f0))))))))))
 
 
   
 #+test
 (defun test-error-function-complement ()
   (dotimes (i 100)
-    (let* ((abs-x (/ i 20.0))		   ; range is 0 to 5.0
+    (let* ((abs-x (/ i 2f1))		   ; range is 0 to 5.0
 	   (x     (if (zerop (random 2)) abs-x (- abs-x)))
 	   (e1    (error-function-complement x))
-	   (e2    (- 1.0 (error-function x)))
+	   (e2    (- 1f0 (error-function x)))
 	   (del   (- e1 e2)))
-      (when (> (abs del) 1e-6)		   ; 10^-6 agreement between the two error functions
+      (when (> (abs del) 1f-6)		   ; 10^-6 agreement between the two error functions
 	(format t "~&on ~7f, difference is ~f" x del)
 	(spy e1 e2))))
   #+Explorer
   ;; The following shows erfcc to be about 4 times faster and does a lot less number-consing
   (time:timeit (:cpu :cons :number-cons :label "erf")
-    (error-function 1.75))
+    (error-function 1.75f0))
   #+Explorer
   (time:timeit (:cpu :cons :number-cons :label "erfcc")
-    (error-function-complement 1.75)))
+    (error-function-complement 1.75f0)))
 
 (defun gaussian-significance (x tails &optional mean sd)
   "Computes the significance of `x' in a Gaussian distribution with mean=`mean'
@@ -504,18 +504,18 @@ alternative hypothesis (H1) via the `tails' parameter, which must be :both,
 :positive, H1 is that `x' is positive, and similarly for :negative."
   (when mean (setf x (- x mean)))
   (when sd   (setf x (/ x sd)))
-  (let ((a (error-function-complement (* (abs x) (/ (sqrt 2.0d0))))))
+  (let ((a (error-function-complement (* (abs x) (/ (sqrt 2.0f0))))))
     ;; A is 2*Integral from x to Infinity of the z distribution
     (ecase tails
       (:both a)
       ;; The TI compiler actually does the right thing with the following code:
       ;; the repeated expressions only appear once in the object code!
       (:positive (if (plusp x)
-		     (* .5 a)
-		     (- 1.0 (* .5 a))))
+		     (* .5f0 a)
+		     (- 1.0f0 (* .5f0 a))))
       (:negative (if (plusp x)
-		     (- 1.0 (* .5 a))
-		     (* .5 a))))))
+		     (- 1.0f0 (* .5f0 a))
+		     (* .5f0 a))))))
 
 ;;; ============================================================================
 
@@ -527,7 +527,7 @@ expected number is `x.' The argument `k' should be an integer, while `x' should
 be a float.  The implementation follows Numerical Recipes in C, section 6.2"
   (check-type k integer)
   (check-type x float)
-  (- 1.0 (gamma-incomplete (float k x) x)))
+  (- 1f0 (gamma-incomplete (float k x) x)))
 
 (defun chi-square-significance (x dof)
   "Computes the complement of the cumulative distribution function for a
@@ -538,7 +538,7 @@ section 6.2.  Small values suggest that the null hypothesis should be rejected;
 in other words, this computes the significance of `x.'"
   (check-type dof integer)
   (check-type x float)
-  (- 1.0 (gamma-incomplete (* 0.5 dof) (* 0.5 x))))
+  (- 1f0 (gamma-incomplete (* 5f-1 dof) (* 5f-1 x))))
 
 ;;; ============================================================================
 
@@ -548,23 +548,23 @@ Student's t and the F distribution.
 
 All arguments must be floating-point numbers; `a' and `b' must be positive and
 `x' must be between 0.0 and 1.0, inclusive."
-   (check-type a (float (0.0) *))
-   (check-type b (float (0.0) *))
-   (check-type x (float 0.0 1.0))
+   (check-type a (float (0f0) *))
+   (check-type b (float (0f0) *))
+   (check-type x (float 0f0 1f0))
    (flet ((betacf (a b x)
 	    ;; straight from Numerical Recipes in C, section 6.3
 	    (declare (type float a b x))
 	    (let ((itmax 100)
-		  (eps   3.0e-7)
-		  (qap 0.0) (qam 0.0) (qab 0.0) (em  0.0) (tem 0.0) (d 0.0)
-		  (bz  0.0) (bm  1.0) (bp  0.0) (bpp 0.0)
-		  (az  1.0) (am  1.0) (ap  0.0) (app 0.0) (aold 0.0))
+		  (eps   3f-7)
+		  (qap 0f0) (qam 0f0) (qab 0f0) (em  0f0) (tem 0f0) (d 0f0)
+		  (bz  0f0) (bm  1f0) (bp  0f0) (bpp 0f0)
+		  (az  1f0) (am  1f0) (ap  0f0) (app 0f0) (aold 0f0))
 	      (declare (type float qap qam qab em tem d
 			     bz bm bp bpp az am ap app aold))
 	      (setf qab (+ a b)
-		    qap (+ a 1.0)
-		    qam (- a 1.0)
-		    bz  (- 1.0 (/ (* qab x) qap)))
+		    qap (+ a 1f0)
+		    qam (- a 1f0)
+		    bz  (- 1f0 (/ (* qab x) qap)))
 	      (dotimes (m itmax)
 		(setf em   (float (1+ m))
 		      tem  (+ em em)
@@ -580,27 +580,27 @@ All arguments must be floating-point numbers; `a' and `b' must be positive and
 		      am   (/ ap bpp)
 		      bm   (/ bp bpp)
 		      az   (/ app bpp)
-		      bz   1.0)
+		      bz   1f0)
 		(if (< (abs (- az aold)) (* eps (abs az)))
 		    (return-from betacf az)))
 	      (error "a=~s or b=~s too big, or itmax too small in betacf"
 		     a b))))
       (declare (notinline betacf))
-      (when (or (< x 0.0) (> x 1.0))
+      (when (or (< x 0f0) (> x 1f0))
 	 (error "x must be between 0.0 and 1.0:  ~f" x))
       ;; bt is the factors in front of the continued fraction
-      (let ((bt (if (or (= x 0.0) (= x 1.0))	    
-		    0.0
+      (let ((bt (if (or (= x 0f0) (= x 1f0))
+		    0f0
 		    (exp (+ (gamma-ln (+ a b))
 			    (- (gamma-ln a))
 			    (- (gamma-ln b))
 			    (* a (log x))
-			    (* b (log (- 1.0 x))))))))
-	 (if (< x (/ (+ a 1.0) (+ a b 2.0)))
+			    (* b (log (- 1f0 x))))))))
+	 (if (< x (/ (+ a 1f0) (+ a b 2f0)))
 	     ;; use continued fraction directly
 	     (/ (* bt (betacf a b x)) a) 
 	     ;; use continued fraction after making the symmetry transformation
-	     (- 1.0 (/ (* bt (betacf b a (- 1.0 x))) b))))))
+	     (- 1f0 (/ (* bt (betacf b a (- 1f0 x))) b))))))
 
 #+test
 (defun test-beta-incomplete ()
@@ -609,25 +609,25 @@ All arguments must be floating-point numbers; `a' and `b' must be positive and
   (flet ((ibf (a b)
 	   (let ((pts nil))
 	     (dotimes (x 101)
-	       (push (list (* .01 x) (beta-incomplete a b (* .01 x))) pts))
+	       (push (list (* 1f-2 x) (beta-incomplete a b (* 1f-2 x))) pts))
 	     `((:polyline-without-vertices ,(format nil "(~f,~f)" a b) 0) .
 	       ,pts))))
     (plotter:plot-stuff
-      (list (ibf 0.5 0.5)
-	    (ibf 0.5 5.0)
-	    (ibf 1.0 3.0)
-	    (ibf 8.0 10.0)
-	    (ibf 5.0 0.5)
+      (list (ibf 0.5f0 0.5f0)
+	    (ibf 0.5f0 5.0f0)
+	    (ibf 1.0f0 3.0f0)
+	    (ibf 8.0f0 10.0f0)
+	    (ibf 5.0f0 0.5f0)
 	    )
-      :y-first -0.05
-      :y-last   1.05
+      :y-first -0.05f0
+      :y-last   1.05f0
       :title
       (format nil "The incomplete beta function I_x(a,b)~%~
                    for five different pairs of (a,b):~2%~
                    ~@{(~f,~f) ~}~2%~
                    Notice that the pairs (0.5,5.0) and (5.0,0.5)~%~
                    are related by reflection symmetry around the diagonal."
-	      0.5 5.0 1.0 3.0 8.0 10.0 0.5 0.5 5.0 0.5))))
+	      0.5f0 5.0f0 1.0f0 3.0f0 8.0f0 10.0f0 0.5f0 0.5f0 5.0f0 0.5f0))))
 
 ;;; ============================================================================
 
@@ -653,18 +653,18 @@ This implementation follows Numerical Recipes in C, section 6.3."
   (check-type dof integer)
   (check-type tails (member :both :positive :negative))
   (setf dof (float dof t-statistic))
-  (let ((a (beta-incomplete (* 0.5 dof) 0.5 (/ dof (+ dof (square t-statistic))))))
+  (let ((a (beta-incomplete (* 0.5f0 dof) 0.5f0 (/ dof (+ dof (square t-statistic))))))
     ;; A is 2*Integral from (abs t-statistic) to Infinity of t-distribution
     (case tails
       (:both a)
       ;; The TI compiler actually does the right thing with the following code:
       ;; the repeated expressions only appear once in the object code!
       (:positive (if (plusp t-statistic)
-		     (* .5 a)
-		     (- 1.0 (* .5 a))))
+		     (* .5f0 a)
+		     (- 1.0f0 (* .5f0 a))))
       (:negative (if (plusp t-statistic)
-		     (- 1.0 (* .5 a))
-		     (* .5 a))))))
+		     (- 1.0f0 (* .5f0 a))
+		     (* .5f0 a))))))
 
 
 
@@ -700,12 +700,12 @@ treated as a boolean.
 This implementation follows Numerical Recipes in C, section 6.3 and the `ftest'
 function in section 13.4.  Some of the documentation is also drawn from the
 section 6.3, since I couldn't improve on their explanation."
-  (check-type f-statistic (float 0.0 *))
+  (check-type f-statistic (float 0.0f0 *))
   (check-type numerator-dof (integer 1 *))
   (check-type denominator-dof (integer 1 *))
   (let ((tail-area (beta-incomplete
 		     (* 0.5 denominator-dof)
-		     (* 0.5 numerator-dof)
+		     (* 0.5f0 numerator-dof)
 		     (float (/ denominator-dof
 			       (+ denominator-dof
 				  (* numerator-dof f-statistic)))))))
@@ -714,9 +714,9 @@ section 6.3, since I couldn't improve on their explanation."
 	;; Because of symmetry, we can double the area, but if H0 is strongly
 	;; viable, the tails can get confused, so we ensure that the area is
 	;; less than 1.0
-	(progn (setf tail-area (* 2.0 tail-area))
-	       (if (> tail-area 1.0)
-		   (- 2.0 tail-area)
+	(progn (setf tail-area (* 2.0f0 tail-area))
+	       (if (> tail-area 1.0f0)
+		   (- 2.0f0 tail-area)
 		   tail-area)))))
 
 ;;; ============================================================================
@@ -729,10 +729,11 @@ approximates the actual computation using the incomplete beta function, but is
 preferable for large `n' \(greater than a dozen or so\) because it avoids
 summing many tiny floating-point numbers.
 
-The implementation follows Numerical Recipes in C, section 6.3."
+The implementation follows Numerical Recipes in C, section 6.3
+."
   (assert (<= k n) () "Can't have more events than trials, so k <= n")
   (if (zerop k)
-      1.0
+      1.0f0
       (beta-incomplete (float k) (float (1+ (- n k))) (float p))))
 
 (defun binomial-cdf-exact (p n k)

--- a/dev/math-utilities.lisp
+++ b/dev/math-utilities.lisp
@@ -61,14 +61,14 @@ run-time double-float contagion.")
 
 ;;; ---------------------------------------------------------------------------
 
-(defconstant +e+ 2.71828182845905423
+(defconstant +e+ 2.71828182845905423d0
   "An approximation of the constant e \(named for Euler!\).")
 
 ;;; ---------------------------------------------------------------------------
 
 (defun degrees->radians (degrees)
   "Convert degrees to radians."
-  (* degrees (/ fpi 180.)))
+  (* degrees (/ fpi 180f0)))
 
 ;;; ---------------------------------------------------------------------------
 
@@ -153,14 +153,16 @@ http://www2.springeronline.com/sgw/cda/frontpage/0,,4-10128-22-13887455-0,00.htm
 
 
 #+test
-(loop for (p r b) in '((.5 .5 .5) (.1 .5 .5) (.1 .5 0) (.1 .5 1) (.5 .1 0) (.5 .1 1))
+(loop for (p r b) in '((.5f0 .5f0 .5f0) (.1f0 .5f0 .5f0) (.1f0 .5f0 0f0)
+                       (.1f0 .5f0 1f0) (.5f0 .1f0 0f0) (.5f0 .1f0 1f0))
       do (format t "~2&f-measure:  ~D ~D ~D = ~5,D" p r b (f-measure p r b))
       do (format t "~&IET-f-val:  ~D ~D ~D = ~5,D" p r b (foo p r b))
       do (format t "~&Other-f-v:  ~D ~D ~D = ~5,D" p r b (bar p r b))
       do (format t "~&foobar--v:  ~D ~D ~D = ~5,D" p r b (bar p r b)))
 
 #+test
-(loop for (p r b) in '((.1 .5 0) (.1 .5 .5) (.1 .5 1.0) (.1 .5 2.0) (.1 .5 3.0))
+(loop for (p r b) in '((.1f0 .5f0 0f0) (.1f0 .5f0 .5f0) (.1f0 .5f0 1.0f0)
+                       (.1f0 .5f0 2.0f0) (.1f0 .5f0 3.0f0))
       ;;;do (format t "~2&f-measure:  ~D ~D ~D = ~5,D" p r b (f-measure p r b))
       do (format t "~2&IET-f-val:  ~D ~D ~D = ~5,D" p r b (foo p r b))
       do (format t "~&Other-f-v:  ~D ~D ~D = ~5,D" p r b (bar p r b)))

--- a/dev/mersenne-twister.lisp
+++ b/dev/mersenne-twister.lisp
@@ -16,7 +16,7 @@ ran1 generate floats 1.3 times faster (somewhat less consing)
       (let ((x 0)
             (g (make-random-number-generator 42 'mt-random-number-generator)))
         (loop repeat 10000 do
-              (setf x (uniform-random g 0.0 1.0)))
+              (setf x (uniform-random g 0f0 1f0)))
         x))
 
 (timeit (:report t)
@@ -44,7 +44,7 @@ ran1 generate floats 1.3 times faster (somewhat less consing)
       (let ((x 0)
             (g (make-random-number-generator 42 'ran1-random-number-generator)))
         (loop repeat 10000 do
-              (setf x (uniform-random g 0.0 1.0)))
+              (setf x (uniform-random g 0f0 1f0)))
         x))
 
 

--- a/dev/smoothing.lisp
+++ b/dev/smoothing.lisp
@@ -37,7 +37,7 @@ sequence of numbers."
   (let ((prev (car data)))
     (map 'list
 	 #'(lambda (x)
-	     (prog1 (/ (+ x prev) 2.0)
+	     (prog1 (/ (+ x prev) 2f0)
 		    (setf prev x)))
 	 data)))
 
@@ -95,7 +95,7 @@ length as `data,' which should be a sequence of numbers."
 	   (when (< b d) (rotatef b d))
 	   (when (< c d) (rotatef c d))
 	   ;; median is mean of `b' and `c'
-	   (/ (+ b c) 2.0)))
+	   (/ (+ b c) 2f0)))
     (let ((n (data-length data)))
       (with-temp-vector (temp (+ n 3))
 	(setf (aref temp 0) (elt data 0))
@@ -158,7 +158,7 @@ ends are handled by duplicating the end elements.  This function is not
 destructive; it returns a list the same length as `data,' which should be a
 sequence of numbers."
   (flet ((weighted-mean (a b c)
-	   (/ (+ a (* 2 b) c) 4.0)))
+	   (/ (+ a (* 2 b) c) 4f0)))
     (let ((n (data-length data)))
       (with-temp-vector (temp (+ n 2))
 	(let ((first (elt data 0)))
@@ -203,7 +203,7 @@ neighbors.  The ends are handled by duplicating the end elements.  This function
 is not destructive; it returns a list the same length as `data,' which should be
 a sequence of numbers."
   (flet ((mean-3 (a b c)
-           (/ (+ a b c) 3.0)))
+           (/ (+ a b c) 3f0)))
     (let ((n (data-length data)))
       (with-temp-vector (temp (+ n 2))
         (setf (aref temp 0) (elt data 0))
@@ -221,7 +221,7 @@ neighbor, and its two right neighbors.  The ends are handled by duplicating the
 end elements.  This function is not destructive; it returns a list the same
 length as `data,' which should be a sequence of numbers."
   (flet ((mean-4 (a b c d)
-	   (/ (+ a b c d) 4.0)))
+	   (/ (+ a b c d) 4f0)))
     (let ((n (data-length data)))
       (with-temp-vector (temp (+ n 3))
 	(setf (aref temp 0) (elt data 0))
@@ -242,7 +242,7 @@ neighbors and its two right neighbors.  The ends are handled by duplicating the
 end elements.  This function is not destructive; it returns a list the same
 length as `data,' which should be a sequence of numbers."
   (flet ((mean-5 (a b c d e)
-           (/ (+ a b c d e) 5.0)))
+           (/ (+ a b c d e) 5f0)))
     (let ((n (data-length data)))
       (with-temp-vector (temp (+ n 4))
 	(let ((first (elt data 0)))

--- a/dev/svd.lisp
+++ b/dev/svd.lisp
@@ -401,7 +401,7 @@ tests the inverse-finding function.  The input is a random square matrix, with
 		(setf (aref a i j) x)
 		(setf (aref u i j) x))))
 	  (svdcmp-df u rank rank w v)
-	  (svzero-df w rank 0.0d0001 2)
+	  (svzero-df w rank 1d-5 2)
 	  (svd-inverse-fast-df u w v a-1 tmp)
 	  (multiply-matrices a-1 a prod)
 	  (dotimes (i rank)

--- a/dev/test-basic-statistics.lisp
+++ b/dev/test-basic-statistics.lisp
@@ -176,8 +176,8 @@ Trap errors and report the result."
 #+(and test Explorer)
 (defun plot-quantile ()
   "This is the example from the manual."
-  (loop for q from 0.0 to 1.0 by (/ 128.0)
-	collect (list (quantile '(2.0 3.0 5.0 8.0 13.0) q) q) into pts
+  (loop for q from 0.0f0 to 1.0f0 by (/ 128.0f0)
+	collect (list (quantile '(2.0f0 3.0f0 5.0f0 8.0f0 13.0f0) q) q) into pts
 	finally (plotter:plot-stuff
 		  `(((:polyline-without-vertices) . ,pts)))))
 
@@ -187,7 +187,7 @@ Trap errors and report the result."
 (test-function 'median)
 #+test
 (defun trimmed-mean-10 (data &rest standard-args)
-  (apply #'trimmed-mean data .1 standard-args))
+  (apply #'trimmed-mean data .1f0 standard-args))
 
 #+test
 (test-function 'trimmed-mean-10)
@@ -200,10 +200,10 @@ Trap errors and report the result."
   (dotimes (i 21)
     (spy (trimmed-mean '(1 2 3 4 5) (/ i 40))))
   (dotimes (i 21)
-    (spy (trimmed-mean '(1.0 2.0 4.0 8.0) (/ i 40))))
-  (spy (trimmed-mean '(1.0 2.0 4.0 8.0) .33 :start 2))
-  (spy (trimmed-mean '(1.0 2.0 4.0 8.0) .33 :end 3))
-  (spy (trimmed-mean '((1.0 a) (2.0 b) (4.0 c) (8.0 d)) .5 :key #'first)))
+    (spy (trimmed-mean '(1.0f0 2.0f0 4.0f0 8.0f0) (/ i 40))))
+  (spy (trimmed-mean '(1.0f0 2.0f0 4.0f0 8.0f0) .33f0 :start 2))
+  (spy (trimmed-mean '(1.0f0 2.0f0 4.0f0 8.0f0) .33f0 :end 3))
+  (spy (trimmed-mean '((1.0f0 a) (2.0f0 b) (4.0f0 c) (8.0f0 d)) .5f0 :key #'first)))
   
   
 
@@ -265,7 +265,7 @@ Trap errors and report the result."
 Statistics for Engineering and the Sciences, by Jay L.  DeVore, published by
 Brooks/Cole Publishing Company, copyright 1982.  The function above computes the
 correct t and does not reject H0."
-  (spy (t-test-one-sample '(27.2 29.3 31.5 28.7 30.2 29.6) :negative 30))
+  (spy (t-test-one-sample '(27.2f0 29.3f0 31.5f0 28.7f0 30.2f0 29.6f0) :negative 30))
   (spy (error-handling (t-test-one-sample 'a :both)))
   (spy (error-handling (t-test-one-sample '() :both)))
   (spy (error-handling (t-test-one-sample '(nil) :both)))
@@ -320,26 +320,26 @@ correct t and does not reject H0."
 	(multiple-value-setq (dd d-count) (d-test group1 group2 tails :h0mean h0mean :times 1000))
 	(format t "tails = ~s; h0mean = ~s~%t-test sig = ~5,3f~%d-test sig = ~5,3f (~d/1000)~2%"
 		tails h0mean
-		t-sig (/ d-count 1000.0) d-count)))
+		t-sig (/ d-count 1f3) d-count)))
     '(dolist (tails '(:positive))
       (dolist (h0mean '(1 2 3 4 5))
 	(multiple-value-setq (tt t-sig) (t-test group1 group2 tails h0mean))
 	(multiple-value-setq (dd d-count) (d-test group1 group2 tails :h0mean h0mean :times 1000))
 	(format t "tails = ~s; h0mean = ~s~%t-test sig = ~5,3f~%d-test sig = ~5,3f (~d/1000)~2%"
 		tails h0mean
-		t-sig (/ d-count 1000.0) d-count)))
+		t-sig (/ d-count 1f3) d-count)))
     (dolist (tails '(:both))
       (dolist (h0mean '(1 2 3 4 5 6 7))
 	(multiple-value-setq (tt t-sig) (t-test group1 group2 tails h0mean))
 	(multiple-value-setq (dd d-count) (d-test group1 group2 tails :h0mean h0mean :times 1000))
 	(format t "tails = ~s; h0mean = ~s~%t-test sig = ~5,3f~%d-test sig = ~5,3f (~d/1000)~2%"
 		tails h0mean
-		t-sig (/ d-count 1000.0) d-count)))))
+		t-sig (/ d-count 1f3) d-count)))))
 
 #+(and test Explorer)
 (defun time-d-test ()
-  (let ((s1 (loop repeat 20 collect (random 10.0)))
-	(s2 (loop repeat 20 collect (+ 2.0 (random 10.0)))))
+  (let ((s1 (loop repeat 20 collect (random 1f1)))
+	(s2 (loop repeat 20 collect (+ 2f0 (random 1f1)))))
     (time:timeit (:cpu :cons :number-cons)
       (t-test s1 s2 :both))
     (time:timeit (:cpu :cons :number-cons)
@@ -352,8 +352,10 @@ Statistics for Engineering and the Sciences, by Jay L.  DeVore, published by
 Brooks/Cole Publishing Company, copyright 1982.  The function above computes the
 correct t and does not reject H0."
   (spy (t-test-matched
-	 '(30.99 31.47 30.00 30.64 35.25 30.62 31.91 31.37 13.22 21.14 27.21 28.27 29.75 24.90 27.86 31.33)
-	 '(30.05 31.75 28.50 31.18 35.12 30.55 31.88 31.05 12.97 21.92 27.26 28.14 30.05 25.10 27.72 31.30)
+	 '(30.99f0 31.47f0 30.00f0 30.64f0 35.25f0 30.62f0 31.91f0 31.37f0
+           13.22f0 21.14f0 27.21f0 28.27f0 29.75f0 24.90f0 27.86f0 31.33f0)
+	 '(30.05f0 31.75f0 28.50f0 31.18f0 35.12f0 30.55f0 31.88f0 31.05f0
+           12.97f0 21.92f0 27.26f0 28.14f0 30.05f0 25.10f0 27.72f0 31.30f0)
 	 :both)))
 
 #+test
@@ -381,8 +383,8 @@ correct t and does not reject H0."
 and Statistics for Engineering and the Sciences, by Jay L.  DeVore, published by
 Brooks/Cole Publishing Company, copyright 1982.  The function above computes the
 correct correlation."
-  (spy (correlation '(1.98 1.44 2.02 1.20 1.57 1.82 1.45 1.80)
-		    '(5.6  7.7  8.8  5.1  6.8  3.9  4.5  5.8)))
+  (spy (correlation '(1.98f0 1.44f0 2.02f0 1.20f0 1.57f0 1.82f0 1.45f0 1.80f0)
+		    '(5.6f0  7.7f0  8.8f0  5.1f0  6.8f0  3.9f0  4.5f0  5.8f0)))
   (spy (error-handling (correlation 'a '(2 3 4 5))))
   (spy (error-handling (correlation '() '(2 3 4 5))))
   (spy (error-handling (correlation '(nil) '(2 3 4 5))))
@@ -425,10 +427,10 @@ correct correlation."
 
 #+test
 (defun test-confidence-interval-z ()
-  (spy (confidence-interval-z '(1 2 3 4 5 6) .9))
-  (spy (confidence-interval-z '(1 2 3 4 5 6) .95))
-  (spy (confidence-interval-z '(1 2 3 4 5 6) .99))
-  (spy (confidence-interval-z '(1 2 3 4 5 6) .999))
+  (spy (confidence-interval-z '(1 2 3 4 5 6) .9f0))
+  (spy (confidence-interval-z '(1 2 3 4 5 6) .95f0))
+  (spy (confidence-interval-z '(1 2 3 4 5 6) .99f0))
+  (spy (confidence-interval-z '(1 2 3 4 5 6) .999f0))
   #+Explorer
   (progn
     (format t "~2&mean~%")
@@ -451,35 +453,36 @@ correct correlation."
 		 (standard-deviation '(1 2 3 4 5 6)))
     (format t "~2&confidence interval-z--cached~%")
     (time:timeit (:cpu :cons)
-		 (confidence-interval-z '(1 2 3 4 5 6) .9)
-		 (confidence-interval-z '(1 2 3 4 5 6) .95)
-		 (confidence-interval-z '(1 2 3 4 5 6) .99)
-		 '(confidence-interval-z '(1 2 3 4 5 6) .999))
+		 (confidence-interval-z '(1 2 3 4 5 6) .9f0)
+		 (confidence-interval-z '(1 2 3 4 5 6) .95f0)
+		 (confidence-interval-z '(1 2 3 4 5 6) .99f0)
+		 '(confidence-interval-z '(1 2 3 4 5 6) .999f0))
     (format t "~2&confidence interval-z--computed~%")
     (time:timeit (:cpu :cons)
-		 (confidence-interval-z '(1 2 3 4 5 6) .9)
-		 (confidence-interval-z '(1 2 3 4 5 6) .95)
-		 (confidence-interval-z '(1 2 3 4 5 6) .99)
-		 (confidence-interval-z '(1 2 3 4 5 6) .999))))
+		 (confidence-interval-z '(1 2 3 4 5 6) .9f0)
+		 (confidence-interval-z '(1 2 3 4 5 6) .95f0)
+		 (confidence-interval-z '(1 2 3 4 5 6) .99f0)
+		 (confidence-interval-z '(1 2 3 4 5 6) .999f0))))
 
 #+test
 (defun test-confidence-interval-t ()
   ;; From DeVore, page 335
   (spy (confidence-interval-t
-	 '(26.7 25.8 24.0 24.9 26.4 25.9 24.4 21.7 24.1 25.9 27.3 26.9 27.3 24.8 23.6)
-	 .95))
+	 '(26.7f0 25.8f0 24.0f0 24.9f0 26.4f0 25.9f0 24.4f0 21.7f0
+           24.1f0 25.9f0 27.3f0 26.9f0 27.3f0 24.8f0 23.6f0)
+	 .95f0))
   (dolist (n '(10 20 30 50 70 90 120 200))
-    (let ((data (loop for i from 1 to n collect (random 1.0)))
+    (let ((data (loop for i from 1 to n collect (random 1.0f0)))
 	  mean z-low z-high t-low t-high)
-      (multiple-value-setq (mean z-low z-high) (confidence-interval-z data .95))
-      (multiple-value-setq (mean t-low t-high) (confidence-interval-t data .95))
+      (multiple-value-setq (mean z-low z-high) (confidence-interval-z data .95f0))
+      (multiple-value-setq (mean t-low t-high) (confidence-interval-t data .95f0))
       (format t "~&dof: ~3d z-width: ~6f t-width: ~6f~%"
 	      n (- z-high z-low) (- t-high t-low)))))
 
 #+test
 (defun test-confidence-interval-proportion ()
   ;; From DeVore, page 331
-  (spy (confidence-interval-proportion 184 244 .90)))
+  (spy (confidence-interval-proportion 184 244 .90f0)))
 
 #+test
 (defun test-anova-one-way-variables ()
@@ -519,17 +522,17 @@ correct correlation."
 #+test
 (defun test-scheffe-tests ()
   ;; From Cohen
-  (let ((means '(4.241 3.754 2.847 2.345))
+  (let ((means '(4.241f0 3.754f0 2.847f0 2.345f0))
 	(sizes '(29 118 59 59)))
-    (spy (scheffe-tests means sizes 1.811 261))))
+    (spy (scheffe-tests means sizes 1.811f0 261))))
 
 #+test
 (defun test-print-scheffe-table ()
   ;; From Cohen
-  (let ((means '(4.241 3.754 2.847 2.345))
+  (let ((means '(4.241f0 3.754f0 2.847f0 2.345f0))
 	(sizes '(29 118 59 59)))
-    (print-scheffe-table (scheffe-tests means sizes 1.811 261))
-    (print-scheffe-table (scheffe-tests means sizes 1.811 261)
+    (print-scheffe-table (scheffe-tests means sizes 1.811f0 261))
+    (print-scheffe-table (scheffe-tests means sizes 1.811f0 261)
 			 means)))
 
 #+test
@@ -553,14 +556,14 @@ correct correlation."
 	       #(199 176 182 200 169 175)
 	       #(186 203 217 197 209 208)
 	       #(191 189 184 188 177 205))
-	    t 0.9))
+	    t 0.9f0))
     ;; with lists of floats
     (test (anova-one-way-groups
-	    '((18.7 21.1 17.9 19.5 22.1 18.3)
-	      (19.9 17.6 18.2 20.0 16.9 17.5)
-	      (18.6 20.3 21.7 19.7 20.9 20.8)
-	      (19.1 18.9 18.4 18.8 17.7 20.5))
-	    t 0.9))
+	    '((18.7f0 21.1f0 17.9f0 19.5f0 22.1f0 18.3f0)
+	      (19.9f0 17.6f0 18.2f0 20.0f0 16.9f0 17.5f0)
+	      (18.6f0 20.3f0 21.7f0 19.7f0 20.9f0 20.8f0)
+	      (19.1f0 18.9f0 18.4f0 18.8f0 17.7f0 20.5f0))
+	    t 0.9f0))
     ;; with arrays of integers
     (test (anova-one-way-variables
 	    '#(a a a a a a b b b b b b c c c c c c d d d d d d)
@@ -568,22 +571,22 @@ correct correlation."
 		   199 176 182 200 169 175
 		   186 203 217 197 209 208
 		   191 189 184 188 177 205)
-	    t 0.9))
+	    t 0.9f0))
     ;; with lists of floats
     (test (anova-one-way-variables	
 	    '(a a a a a a b b b b b b c c c c c c d d d d d d)
-	    '(18.7 21.1 17.9 19.5 22.1 18.3
-		   19.9 17.6 18.2 20.0 16.9 17.5
-		   18.6 20.3 21.7 19.7 20.9 20.8
-		   19.1 18.9 18.4 18.8 17.7 20.5)
-	    t 0.9))
+	    '(18.7f0 21.1f0 17.9f0 19.5f0 22.1f0 18.3f0
+              19.9f0 17.6f0 18.2f0 20.0f0 16.9f0 17.5f0
+              18.6f0 20.3f0 21.7f0 19.7f0 20.9f0 20.8f0
+              19.1f0 18.9f0 18.4f0 18.8f0 17.7f0 20.5f0)
+	    t 0.9f0))
     ))
 #+test
 (defun test-anova-two-way-groups ()
   ;; example 11.4 from Devore
-  (let* ((data  '#(10.5 9.2 7.9 12.8 11.2 13.3 12.1 12.6 14.0 10.8 9.1 12.5
-			8.1 8.6 10.1 12.7 13.7 11.5 14.4 15.4 13.7 11.3 12.5 14.5
-			16.1 15.3 17.5 16.6 19.2 18.5 20.8 18.0 21.0 18.4 18.9 17.2))
+  (let* ((data  '#(10.5f0 9.2f0 7.9f0 12.8f0 11.2f0 13.3f0 12.1f0 12.6f0 14.0f0 10.8f0 9.1f0 12.5f0
+                   8.1f0 8.6f0 10.1f0 12.7f0 13.7f0 11.5f0 14.4f0 15.4f0 13.7f0 11.3f0 12.5f0 14.5f0
+                   16.1f0 15.3f0 17.5f0 16.6f0 19.2f0 18.5f0 20.8f0 18.0f0 21.0f0 18.4f0 18.9f0 17.2f0))
 	 (data3 (make-array '(3 4 3) :displaced-to data)))
     (loop for i from 0 below 3 do
 	  (loop for j from 0 below 4 do
@@ -622,7 +625,10 @@ correct correlation."
 (defun test-anova-two-way-variables-unequal-cell-sizes-3 ()
   (let ((iv2 '(10   10  10  20   30   40   10  10  10   20   20   20   30   30   30   40   40   40   30   30   30   40   10   10   10   20   20   20   30   30   30   40))
         (iv1 '(H    H   H   H    H    H    IFE IFE IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  IFE  P    P    P    P    P    P    P    P    P    P))
-        (dv  '(10.5 9.2 7.9 12.8 14.0 12.5 8.1 8.6 10.1 12.7 13.7 11.5 14.4 15.4 13.7 11.3 12.5 14.5 14.4 15.4 13.7 14.5 16.1 15.3 17.5 16.6 19.2 18.5 20.8 18.0 21.0 18.4)))
+        (dv  '(10.5f0 9.2f0 7.9f0 12.8f0 14.0f0 12.5f0 8.1f0 8.6f0
+               10.1f0 12.7f0 13.7f0 11.5f0 14.4f0 15.4f0 13.7f0 11.3f0
+               12.5f0 14.5f0 14.4f0 15.4f0 13.7f0 14.5f0 16.1f0 15.3f0
+               17.5f0 16.6f0 19.2f0 18.5f0 20.8f0 18.0f0 21.0f0 18.4f0)))
     (multiple-value-bind (table ab-matrix row-totals column-totals grand-total a-list b-list cell-counts)
         (anova-two-way-variables-unequal-cell-sizes dv iv1 iv2)
       (print-anova-table table)
@@ -858,9 +864,9 @@ correct correlation."
 	(iv2 '(10 10 10 20 20 20 30 30 30 40 40 40
 		  10 10 10 20 20 20 30 30 30 40 40 40
 		  10 10 10 20 20 20 30 30 30 40 40 40))
-	(dv  '(10.5 9.2 7.9 12.8 11.2 13.3 12.1 12.6 14.0 10.8 9.1 12.5 
-		    8.1 8.6 10.1 12.7 13.7 11.5 14.4 15.4 13.7 11.3 12.5 14.5 
-		    16.1 15.3 17.5 16.6 19.2 18.5 20.8 18.0 21.0 18.4 18.9 17.2)))
+	(dv  '(10.5f0 9.2f0 7.9f0 12.8f0 11.2f0 13.3f0 12.1f0 12.6f0 14.0f0 10.8f0 9.1f0 12.5f0
+               8.1f0 8.6f0 10.1f0 12.7f0 13.7f0 11.5f0 14.4f0 15.4f0 13.7f0 11.3f0 12.5f0 14.5f0
+               16.1f0 15.3f0 17.5f0 16.6f0 19.2f0 18.5f0 20.8f0 18.0f0 21.0f0 18.4f0 18.9f0 17.2f0)))
     (let ((data3 (make-3d-table dv iv1 iv2)))
       (loop for i from 0 below 3 do
 	    (loop for j from 0 below 4 do
@@ -874,19 +880,20 @@ correct correlation."
 #+test
 (defun test-linear-regression-minimal ()
   ;; example 12.1 from Devore
-  (let ((iv '(2.5 5 10 15 17.5 20 25 30 35 40))
+  (let ((iv '(2.5f0 5 10 15 17.5f0 20 25 30 35 40))
 	(dv '(63 58 55 61 62 37 38 45 46 19)))
     (spy (linear-regression-minimal dv iv))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons) (linear-regression-brief dv iv)))
   ;; example 12.2 from Devore
   (let ((iv '(300 350 400 400 450 450 480 480 530 530 580 580 620 620 670 700))
-	(dv '(5.8 4.5 5.9 6.2 6.0 7.5 6.1 8.6 8.9 8.2 14.2 11.9 11.1 11.5 14.5 14.8)))
+	(dv '(5.8f0 4.5f0 5.9f0 6.2f0 6.0f0 7.5f0 6.1f0 8.6f0
+              8.9f0 8.2f0 14.2f0 11.9f0 11.1f0 11.5f0 14.5f0 14.8f0)))
     (spy (linear-regression-minimal dv iv))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons) (linear-regression-brief dv iv)))
   ;; example 12.3 from Devore
-  (let ((iv '(8.3 8.3 12.1 12.1 17.0 17.0 17.0 24.3 24.3 24.3 33.6))
+  (let ((iv '(8.3f0 8.3f0 12.1f0 12.1f0 17.0f0 17.0f0 17.0f0 24.3f0 24.3f0 24.3f0 33.6f0))
 	(dv '(227 312 362 521 640 539 728 945 738 759 1263)))
     (spy (linear-regression-minimal dv iv))
     #+Explorer
@@ -896,19 +903,20 @@ correct correlation."
 #+test
 (defun test-linear-regression-brief-summaries ()
   ;; example 12.1 from Devore
-  (let ((iv '(2.5 5 10 15 17.5 20 25 30 35 40))
+  (let ((iv '(2.5f0 5 10 15 17.5f0 20 25 30 35 40))
 	(dv '(63 58 55 61 62 37 38 45 46 19)))
     (spy (linear-regression-brief dv iv))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons) (linear-regression-brief dv iv)))
   ;; example 12.2 from Devore
   (let ((iv '(300 350 400 400 450 450 480 480 530 530 580 580 620 620 670 700))
-	(dv '(5.8 4.5 5.9 6.2 6.0 7.5 6.1 8.6 8.9 8.2 14.2 11.9 11.1 11.5 14.5 14.8)))
+	(dv '(5.8f0 4.5f0 5.9f0 6.2f0 6.0f0 7.5f0 6.1f0 8.6f0
+              8.9f0 8.2f0 14.2f0 11.9f0 11.1f0 11.5f0 14.5f0 14.8f0)))
     (spy (linear-regression-brief dv iv))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons) (linear-regression-brief dv iv)))
   ;; example 12.3 from Devore
-  (let ((iv '(8.3 8.3 12.1 12.1 17.0 17.0 17.0 24.3 24.3 24.3 33.6))
+  (let ((iv '(8.3f0 8.3f0 12.1f0 12.1f0 17.0f0 17.0f0 17.0f0 24.3f0 24.3f0 24.3f0 33.6f0))
 	(dv '(227 312 362 521 640 539 728 945 738 759 1263)))
     (spy (linear-regression-brief dv iv))
     #+Explorer
@@ -928,7 +936,7 @@ correct correlation."
       (linear-regression-brief-summaries 32 3893 290 478537 4160 36473))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons)
-      (linear-regression-brief-summaries 32 3893.0 290.0 478537.0 4160.0 36473.0)))
+      (linear-regression-brief-summaries 32 3893.0f0 290.0f0 478537.0f0 4160.0f0 36473.0f0)))
   ;; example 12.5 from Devore.  The p-value doesn't match Devore's because his
   ;; example is testing whether slope=20, rather than whether slope=0.
   (let ((iv '(78 75 78 81 84 86 87))
@@ -942,13 +950,13 @@ correct correlation."
 	  (spy t-stat
 	       dof
 	       (students-t-significance t-stat dof :positive)
-	       (confidence-interval-t-summaries slope dof se-slope .95)))))
+	       (confidence-interval-t-summaries slope dof se-slope .95f0)))))
     #+Explorer
     (time:timeit (:cpu :cons :number-cons)
       (linear-regression-brief dv iv)))
   ;; example 12.10 from Devore
-  (let ((iv '(1.98 1.44 2.02 1.20 1.57 1.82 1.45 1.80))
-	(dv '(5.6 7.7 8.8 5.1 6.8 3.9 4.5 5.8)))
+  (let ((iv '(1.98f0 1.44f0 2.02f0 1.20f0 1.57f0 1.82f0 1.45f0 1.80f0))
+	(dv '(5.6f0 7.7f0 8.8f0 5.1f0 6.8f0 3.9f0 4.5f0 5.8f0)))
     (multiple-value-bind (ignore ignore r2) (linear-regression-brief dv iv)
       (spy (sqrt r2)))
     #+Explorer
@@ -989,7 +997,7 @@ correct correlation."
 #+test
 (defun test-multiple-linear-regression-normal ()
   (multiple-value-bind (dv ivs)
-      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4) 50 10.0)
+      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4) 50 10.0f0)
     (spy (apply #'multiple-linear-regression-normal dv ivs))))
 
 #+test
@@ -1003,8 +1011,14 @@ MSE = 1.18
 R2  = .965
 F   = 344.64
 "
-  (let ((y '(30.9 32.7 36.7 41.9 40.9 42.9 46.3 47.6 47.2 44.0 47.7 43.9 46.8 46.2 47.0 46.8 45.9 48.8 46.2 47.8 49.2 48.3 48.6 50.2 49.6 53.2 54.3 55.8))
-	(x1 '(8.5 8.9 10.6 10.2 9.8 10.8 11.6 12.0 12.5 10.9 12.2 11.9 11.3 13.0 12.9 12.0 12.9 13.1 11.4 13.2 11.6 12.1 11.3 11.1 11.5 11.6 11.7 11.7))
+  (let ((y '(30.9f0 32.7f0 36.7f0 41.9f0 40.9f0 42.9f0 46.3f0 47.6f0
+             47.2f0 44.0f0 47.7f0 43.9f0 46.8f0 46.2f0 47.0f0 46.8f0
+             45.9f0 48.8f0 46.2f0 47.8f0 49.2f0 48.3f0 48.6f0 50.2f0
+             49.6f0 53.2f0 54.3f0 55.8f0))
+	(x1 '(8.5f0 8.9f0 10.6f0 10.2f0 9.8f0 10.8f0 11.6f0 12.0f0
+              12.5f0 10.9f0 12.2f0 11.9f0 11.3f0 13.0f0 12.9f0
+              12.0f0 12.9f0 13.1f0 11.4f0 13.2f0 11.6f0 12.1f0
+              11.3f0 11.1f0 11.5f0 11.6f0 11.7f0 11.7f0))
 	(x2 '(2 3 3 20 22 20 31 32 31 28 36 28 30 27 24 25 28 28 32 28 35 34 35 40 45 50 55 57)))
     ;; Test that the data are typed in correctly.  They are
     '(progn 
@@ -1029,12 +1043,12 @@ F   = 344.64
 
 #+test
 (defun generate-test-data-for-multiple-linear-regression
-       (true-intercept true-coefs num-data &optional (sd 1.0))
+       (true-intercept true-coefs num-data &optional (sd 1.0f0))
   "Generates a list of dv values and a list of lists of iv values."
   (let ((dv nil)
 	(ivs (loop for x in true-coefs collect nil)))
     (dotimes (i num-data)
-      (let ((xs (loop for c in true-coefs collect (random 100.0))))
+      (let ((xs (loop for c in true-coefs collect (random 1f2))))
 	;; record the independent variables
 	(do ((iv-list ivs (cdr iv-list))
 	     (x-list  xs  (cdr x-list)))
@@ -1045,7 +1059,7 @@ F   = 344.64
 	(push (loop for x in xs
 		    for c in true-coefs
 		    sum (* x c) into s
-		    finally (return (+ true-intercept s (math:normal-random 0.0 sd))))
+		    finally (return (+ true-intercept s (math:normal-random 0f0 sd))))
 	      dv)))
     (values dv ivs)))
 
@@ -1069,7 +1083,7 @@ F   = 344.64
 #+test
 (defun test-multiple-linear-regression-brief ()
   (multiple-value-bind (dv ivs)
-      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4) 1000 1.0)
+      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4) 1000 1f0)
     (spy (apply #'multiple-linear-regression-brief dv ivs))
     (multiple-value-bind (int coefs r-list t-bs betas r-square f ss-regs ss-percent ss-reg ss-res mse-reg mse-res)
 	(apply #'multiple-linear-regression-normal dv ivs)
@@ -1091,7 +1105,7 @@ F   = 344.64
 #+test
 (defun test-MLR-verbose-vs-LR-vs-MLR ()
   (multiple-value-bind (dv ivs)
-      (generate-test-data-for-multiple-linear-regression 1 '(5) 10 10.0)
+      (generate-test-data-for-multiple-linear-regression 1 '(5) 10 1f1)
     (spy (linear-regression-verbose dv (car ivs)))
     (spy (apply #'multiple-linear-regression-normal dv ivs))
     (spy (apply #'multiple-linear-regression-verbose dv ivs))))
@@ -1099,7 +1113,7 @@ F   = 344.64
 #+test
 (defun test-multiple-linear-regression-verbose ()
   (multiple-value-bind (dv ivs)
-      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4 10) 10 5.0)
+      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4 10) 10 5f0)
     (time:timeit (:cpu :label "svd") (apply #'multiple-linear-regression-verbose dv ivs))
     (time:timeit (:cpu :label "norm") (apply #'multiple-linear-regression-normal dv ivs))
     (let ((v1 (multiple-value-list (apply #'multiple-linear-regression-verbose dv ivs)))
@@ -1113,9 +1127,9 @@ F   = 344.64
 #+test
 (defun test-multiple-linear-regression-verbose-on-degenerate-data ()
   (multiple-value-bind (dv ivs)
-      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4 10) 100 5.0)
+      (generate-test-data-for-multiple-linear-regression 1 '(2 3 4 10) 100 5f0)
     ;; create a degenerate column
-    (push (mapcar #'(lambda (a b c) (+ (* 1.5 a) (* 2.5 b) (* 3.5 c)))
+    (push (mapcar #'(lambda (a b c) (+ (* 1.5f0 a) (* 2.5f0 b) (* 3.5f0 c)))
 		  (car ivs) (cadr ivs) (caddr ivs))
 	  ivs)
     (let ((v1 (multiple-value-list (apply #'multiple-linear-regression-verbose dv ivs)))

--- a/dev/test-math-utilities.lisp
+++ b/dev/test-math-utilities.lisp
@@ -2,8 +2,8 @@
 
 (deftestsuite on-interval () ()
   (:tests 
-   ((ensure (on-interval 1.0 0 1)))
-   ((ensure (not (on-interval 1.0 0 1 :upper-inclusive? nil))))
+   ((ensure (on-interval 1.0f0 0 1)))
+   ((ensure (not (on-interval 1.0f0 0 1 :upper-inclusive? nil))))
    ((ensure (on-interval 0 0 1)))
    ((ensure (not (on-interval 0 0 1 :lower-inclusive? nil))))
    ((ensure (not (on-interval 2 0 1))))


### PR DESCRIPTION
Still passes all tests.

Important if _r-d-f-f_ is 'double-float.
